### PR TITLE
feat(XWayland): add window watching methods/signals and fetching of PID from window and window from PID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,7 +506,7 @@ dependencies = [
 
 [[package]]
 name = "gamescope-dbus"
-version = "1.0.3"
+version = "1.1.0"
 dependencies = [
  "gamescope-wayland-client",
  "gamescope-x11-client",
@@ -533,7 +533,7 @@ dependencies = [
 [[package]]
 name = "gamescope-x11-client"
 version = "0.1.0"
-source = "git+https://github.com/ShadowBlip/gamescope-x11-client.git#f2be4fa5e7936e42cb6317882b1907ea61e877d4"
+source = "git+https://github.com/ShadowBlip/gamescope-x11-client.git?rev=f02fa9c07a357a85c31417390910aa4babfa3771#f02fa9c07a357a85c31417390910aa4babfa3771"
 dependencies = [
  "strum",
  "strum_macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,4 @@ zbus = { version = "3.14.1", default-features = false, features = ["tokio"] }
 zbus_macros = "3.14.1"
 inotify = "0.10.2"
 gamescope-wayland-client = { git = "https://github.com/ShadowBlip/gamescope-wayland-client.git", version = "0.1.0" }
-gamescope-x11-client = { git = "https://github.com/ShadowBlip/gamescope-x11-client.git", version = "0.1.0" }
+gamescope-x11-client = { git = "https://github.com/ShadowBlip/gamescope-x11-client.git", rev = "f02fa9c07a357a85c31417390910aa4babfa3771" }

--- a/src/gamescope/manager.rs
+++ b/src/gamescope/manager.rs
@@ -190,8 +190,9 @@ impl Manager {
             }
 
             // Create a new DBus interface to the xwayland instance
-            let instance = xwayland::DBusInterface::new(name.clone())?;
             let path = format!("/org/shadowblip/Gamescope/XWayland{}", i);
+            let instance =
+                xwayland::DBusInterface::new(name.clone(), path.clone(), self.dbus.clone())?;
 
             // Check to see if this is a primary xwayland instance. If it is,
             // also attach the dbus interface with extra methods
@@ -202,8 +203,12 @@ impl Manager {
                 self.dbus.object_server().at(path.clone(), primary).await?;
 
                 // Propagate gamescope changes to DBus signals
-                xwayland::dispatch_property_changes(self.dbus.clone(), path.clone(), changes_rx)
-                    .await?;
+                xwayland::dispatch_primary_property_changes(
+                    self.dbus.clone(),
+                    path.clone(),
+                    changes_rx,
+                )
+                .await?;
             }
 
             self.dbus.object_server().at(path.clone(), instance).await?;


### PR DESCRIPTION
This change adds methods for starting to watch window property changes. When watching a window, the `WindowPropertyChanged` signal will fire for the window.

This change also adds methods for fetching the process ID from a window, and fetching the window from a process ID.