### PR TITLE
Remove br tag from title to fix search engine results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,7 +506,7 @@ dependencies = [
 
 [[package]]
 name = "gamescope-dbus"
-version = "1.4.1"
+version = "1.3.0"
 dependencies = [
  "gamescope-wayland-client",
  "gamescope-x11-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,7 +506,7 @@ dependencies = [
 
 [[package]]
 name = "gamescope-dbus"
-version = "1.3.0"
+version = "1.4.1"
 dependencies = [
  "gamescope-wayland-client",
  "gamescope-x11-client",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
+<br>
 <h1 align="center">
-  <br>
   Gamescope DBus
 </h1>
 
@@ -44,10 +44,9 @@ XML specifications for all interfaces can be found in [bindings/dbus-xml](./bind
 
 Individual interface documentation can be found here:
 
-* [org.shadowblip.Gamescope.Manager](./docs/manager.md)
-* [org.shadowblip.Gamescope.XWayland](./docs/xwayland.md)
-* [org.shadowblip.Gamescope.Wayland](./docs/wayland.md)
-
+- [org.shadowblip.Gamescope.Manager](./docs/manager.md)
+- [org.shadowblip.Gamescope.XWayland](./docs/xwayland.md)
+- [org.shadowblip.Gamescope.Wayland](./docs/wayland.md)
 
 ## Usage
 
@@ -61,7 +60,6 @@ You can also interface with DBus using the `busctl` command:
 busctl --user tree org.shadowblip.Gamescope
 ```
 
-
 ```bash
 └─ /org
   └─ /org/shadowblip
@@ -71,7 +69,6 @@ busctl --user tree org.shadowblip.Gamescope
       ├─ /org/shadowblip/Gamescope/XWayland0
       └─ /org/shadowblip/Gamescope/XWayland1
 ```
-
 
 ```bash
 busctl --user introspect org.shadowblip.Gamescope /org/shadowblip/Gamescope/XWayland0


### PR DESCRIPTION
When searching for gamescope_dbus on search engines, the results show newline characters likely caused by some bad parsing on Github's side.

![image](https://github.com/user-attachments/assets/99bff236-516a-412d-9ade-b1f0068aed59)

I moved the `<br>` tag outside of the `<h1>` title which should fix the issue next time the page is re-indexed.

Also updated Cargo.lock to the current release. 