### PR TITLE
feat(XWayland): add mode control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,7 +538,7 @@ dependencies = [
 [[package]]
 name = "gamescope-x11-client"
 version = "0.1.0"
-source = "git+https://github.com/ShadowBlip/gamescope-x11-client.git?rev=9526a6e0d684d9530e8705f7f1a53efa401350f3#9526a6e0d684d9530e8705f7f1a53efa401350f3"
+source = "git+https://github.com/ShadowBlip/gamescope-x11-client.git?rev=9d3ef5a360bbc8123e1af366e02de92314769052#9d3ef5a360bbc8123e1af366e02de92314769052"
 dependencies = [
  "log",
  "strum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ zbus = { version = "3.15.2", default-features = false, features = ["tokio"] }
 zbus_macros = "3.15.2"
 inotify = "0.11.0"
 gamescope-wayland-client = { git = "https://github.com/ShadowBlip/gamescope-wayland-client.git", version = "0.1.0" }
-gamescope-x11-client = { git = "https://github.com/ShadowBlip/gamescope-x11-client.git", rev = "9526a6e0d684d9530e8705f7f1a53efa401350f3" }
+gamescope-x11-client = { git = "https://github.com/ShadowBlip/gamescope-x11-client.git", rev = "9d3ef5a360bbc8123e1af366e02de92314769052" }
 serde = "1.0.214"
 nix = { version = "0.29.0", features = ["user"] }
 tokio-stream = "0.1.17"

--- a/src/gamescope/xwayland.rs
+++ b/src/gamescope/xwayland.rs
@@ -734,6 +734,22 @@ impl DBusInterfacePrimary {
             .map_err(|err| fdo::Error::Failed(err.to_string()))?;
         Ok(())
     }
+
+    /// Sets the display mode control for Gamescope on the given xwayland instance
+    /// to change the display resolution.
+    async fn set_mode_control(
+        &self,
+        xwayland_id: u32,
+        width: u32,
+        height: u32,
+        super_res: u32,
+    ) -> fdo::Result<()> {
+        self.ensure_connected().await;
+        self.xwayland
+            .set_mode_control(xwayland_id, width, height, super_res)
+            .map_err(|err| fdo::Error::Failed(err.to_string()))?;
+        Ok(())
+    }
 }
 
 /// Listen for property changes and emit the appropriate DBus signals. This is


### PR DESCRIPTION
This change adds mode control (added by @gabefraser) to the XWayland Primary interface to control the display resolution.

This can be tested using `busctl`:

```bash
busctl --user call org.shadowblip.Gamescope /org/shadowblip/Gamescope/XWayland0 org.shadowblip.Gamescope.XWayland.Primary SetModeControl uuuu 1 800 600 0
```