### PR TITLE
fix: remove dbus specific service config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ description = "Daemon for interacting with Gamescope over DBus"
 assets = [
   { source = "target/release/gamescope-dbus", dest = "/usr/bin/gamescope-dbus", mode = "755" },
   { source = "./rootfs/usr/share/dbus-1/session.d/org.shadowblip.Gamescope.conf", dest = "/usr/share/dbus-1/session.d/org.shadowblip.Gamescope.conf", mode = "644" },
-  { source = "./rootfs/usr/share/dbus-1/services/org.shadowblip.Gamescope.service", dest = "/usr/share/dbus-1/services/org.shadowblip.Gamescope.service", mode = "644" },
   { source = "./rootfs/usr/lib/systemd/user/gamescope-dbus.service", dest = "/usr/lib/systemd/user/gamescope-dbus.service", mode = "644" },
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,6 @@ install: build ## Install gamescope-dbus to the given prefix (default: PREFIX=/u
 		$(PREFIX)/bin/$(NAME)
 	install -D -m 644 rootfs/usr/share/dbus-1/session.d/$(DBUS_NAME).conf \
 		$(PREFIX)/share/dbus-1/session.d/$(DBUS_NAME).conf
-	install -D -m 644 rootfs/usr/share/dbus-1/services/$(DBUS_NAME).service \
-		$(PREFIX)/share/dbus-1/services/$(DBUS_NAME).service
 	install -D -m 644 rootfs/usr/lib/systemd/user/$(NAME).service \
 		$(PREFIX)/lib/systemd/user/$(NAME).service
 	@echo ""
@@ -46,7 +44,6 @@ install: build ## Install gamescope-dbus to the given prefix (default: PREFIX=/u
 uninstall: ## Uninstall gamescope-dbus 
 	rm $(PREFIX)/bin/$(NAME)
 	rm $(PREFIX)/share/dbus-1/session.d/$(DBUS_NAME).conf
-	rm $(PREFIX)/share/dbus-1/services/$(DBUS_NAME).service
 	rm $(PREFIX)/lib/systemd/user/$(NAME).service
 	@echo ""
 	@echo "Uninstall completed. Remove service with:" 

--- a/rootfs/usr/lib/systemd/user/gamescope-dbus.service
+++ b/rootfs/usr/lib/systemd/user/gamescope-dbus.service
@@ -2,9 +2,11 @@
 Description=Gamescope DBus Service
 
 [Service]
-Type=dbus
-BusName=org.shadowblip.Gamescope
 ExecStart=/usr/bin/gamescope-dbus
+Restart=on-failure
+RestartSec=1s
+TimeoutStartSec=5s
+TimeoutStopSec=3s
 
 [Install]
 WantedBy=default.target

--- a/rootfs/usr/share/dbus-1/services/org.shadowblip.Gamescope.service
+++ b/rootfs/usr/share/dbus-1/services/org.shadowblip.Gamescope.service
@@ -1,3 +1,0 @@
-[D-BUS Service]
-Name=org.shadowblip.Gamescope
-Exec=/usr/bin/gamescope-dbus

--- a/rootfs/usr/share/dbus-1/session.d/org.shadowblip.Gamescope.conf
+++ b/rootfs/usr/share/dbus-1/session.d/org.shadowblip.Gamescope.conf
@@ -2,12 +2,9 @@
 <!-- -*- XML -*- -->
 <!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
-  <!-- Only root can own the service -->
-  <policy user="root">
-    <allow own="org.shadowblip.Gamescope"/>
-  </policy>
-  <!-- Anyone can send messages to the owner of org.shadowblip.Gamescope-->
+  <!-- Allow the user to own the service -->
   <policy context="default">
+    <allow own="org.shadowblip.Gamescope"/>
     <allow send_destination="org.shadowblip.Gamescope"/>
   </policy>
 </busconfig>


### PR DESCRIPTION
Basically the gist of this change is that having this service managed by dbus.service causes issues and duplicate processes that cause systemctl to fail spawning a new process and block the system in a way that any bus call to gamescope-dbus fails

```
$systemctl restart sddm
$ps aux | grep gamescope-dbus
user    6567  0.0  0.0 1834244 7236 ?        Ssl  10:20   0:00 /usr/bin/gamescope-dbus
user    8329  0.2  0.0 1834288 7276 ?        Ssl  10:25   0:00 /usr/bin/gamescope-dbus
user    8890  0.0  0.0   6496  2044 pts/0    S+   10:25   0:00 grep --color=auto gamescope-dbus
```

As you can see above, two processes when restarting the session..
Make the service Type=simple resolves that issue