### PR TITLE
fix: fix mango deadlocks when calling update in Metrics interface

### DIFF
--- a/src/gamescope/wayland/metrics/dbus.rs
+++ b/src/gamescope/wayland/metrics/dbus.rs
@@ -1,39 +1,75 @@
-use std::time::SystemTime;
-
-use gamescope_wayland_client::mangoapp::{
-    message::MangoAppMsgV1,
-    queue::{MangoAppMsgQueue, QueueError},
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    thread::JoinHandle,
+    time::{Duration, SystemTime},
 };
+
+use gamescope_wayland_client::mangoapp::message::MangoAppMsgV1;
 use thiserror::Error;
+use tokio::time::{error::Elapsed, timeout};
 use zbus::{dbus_interface, fdo};
+
+use crate::gamescope::wayland::metrics::mango_app_reader::MangoAppMsgQueueReader;
 
 #[derive(Error, Debug)]
 pub enum MetricsError {
     #[error("failed to read metrics message from gamescope: {0}")]
-    QueueError(#[from] QueueError),
+    QueueError(#[from] tokio::sync::watch::error::RecvError),
+    #[error("timedout trying to read gamescope queue message: {0}")]
+    QueueTimeout(#[from] Elapsed),
 }
 
 impl From<MetricsError> for fdo::Error {
     fn from(value: MetricsError) -> Self {
         match value {
             MetricsError::QueueError(queue_error) => fdo::Error::Failed(queue_error.to_string()),
+            MetricsError::QueueTimeout(queue_error) => fdo::Error::Failed(queue_error.to_string()),
         }
     }
 }
 
 pub struct DBusInterface {
-    queue: MangoAppMsgQueue,
+    handle: Option<JoinHandle<()>>,
+    cancel_flag: Arc<AtomicBool>,
     state: Option<MangoAppMsgV1>,
     last_update: SystemTime,
+    request_tx: std::sync::mpsc::Sender<()>,
+    response_rx: tokio::sync::watch::Receiver<Option<MangoAppMsgV1>>,
+}
+
+impl Drop for DBusInterface {
+    fn drop(&mut self) {
+        self.cancel_flag.store(true, Ordering::Relaxed);
+        let _ = self.request_tx.send(());
+
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
 }
 
 impl DBusInterface {
     pub fn new() -> Self {
-        let queue = MangoAppMsgQueue::new();
+        let (response_tx, response_rx) = tokio::sync::watch::channel::<Option<MangoAppMsgV1>>(None);
+        let (request_tx, request_rx) = std::sync::mpsc::channel::<()>();
+        let cancel_flag = Arc::new(AtomicBool::new(false));
+        let cancel_flag_thread = cancel_flag.clone();
+
+        let handle = std::thread::spawn(move || {
+            let reader = MangoAppMsgQueueReader::new(request_rx, response_tx);
+            reader.run(cancel_flag_thread);
+        });
+
         Self {
-            queue,
+            handle: Some(handle),
+            cancel_flag,
             state: None,
             last_update: SystemTime::now(),
+            request_tx,
+            response_rx,
         }
     }
 }
@@ -43,10 +79,26 @@ impl DBusInterface {
     /// Update the metrics from gamescope. This should be called regularly to
     /// get the latest frame metrics. Note that calling this frequently can
     /// interfere with MangoApp framerate stats.
-    pub fn update(&mut self) -> fdo::Result<()> {
-        let msg = self.queue.recv().map_err(MetricsError::from)?;
-        self.state = Some(msg);
-        self.last_update = SystemTime::now();
+    pub async fn update(&mut self) -> fdo::Result<()> {
+        if let Err(err) = self.request_tx.send(()) {
+            log::error!("Error requesting mangoapp queue update, err:{err:?}");
+            return Err(fdo::Error::Failed("Mangoapp queue reader error".to_owned()));
+        }
+
+        timeout(Duration::from_millis(10), self.response_rx.changed())
+            .await
+            .map_err(MetricsError::from)?
+            .map_err(MetricsError::from)?;
+
+        let msg = &*self.response_rx.borrow();
+
+        if let Some(msg) = msg {
+            if self.state.is_none_or(|state| state != *msg) {
+                self.state = Some(*msg);
+                self.last_update = SystemTime::now();
+            }
+        }
+
         Ok(())
     }
 

--- a/src/gamescope/wayland/metrics/mango_app_reader.rs
+++ b/src/gamescope/wayland/metrics/mango_app_reader.rs
@@ -1,0 +1,44 @@
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+
+use gamescope_wayland_client::mangoapp::{message::MangoAppMsgV1, queue::MangoAppMsgQueue};
+
+pub struct MangoAppMsgQueueReader {
+    queue: MangoAppMsgQueue,
+    rx: std::sync::mpsc::Receiver<()>,
+    tx: tokio::sync::watch::Sender<Option<MangoAppMsgV1>>,
+}
+
+impl MangoAppMsgQueueReader {
+    pub fn new(
+        rx: std::sync::mpsc::Receiver<()>,
+        tx: tokio::sync::watch::Sender<Option<MangoAppMsgV1>>,
+    ) -> Self {
+        log::debug!("Starting new mango app msg queue reader");
+
+        let queue = MangoAppMsgQueue::new();
+        Self { queue, rx, tx }
+    }
+
+    pub fn run(mut self, cancel_flag: Arc<AtomicBool>) {
+        while !cancel_flag.load(Ordering::SeqCst) && self.rx.recv().is_ok() {
+            let msg = match self.queue.recv() {
+                Ok(msg) => msg,
+                Err(err) => {
+                    log::debug!("Failed to read from queue: {err}");
+                    if let Err(err) = self.tx.send(None) {
+                        log::error!("Error sending mango app error msg response, err:{err:?}");
+                    }
+                    continue;
+                }
+            };
+
+            if let Err(err) = self.tx.send(Some(msg)) {
+                log::error!("Error sending mango app msg response, err:{err:?}");
+            }
+        }
+        log::debug!("Stopped reading from message queue");
+    }
+}

--- a/src/gamescope/wayland/metrics/mod.rs
+++ b/src/gamescope/wayland/metrics/mod.rs
@@ -1,1 +1,2 @@
 pub mod dbus;
+pub mod mango_app_reader;


### PR DESCRIPTION
When restarting session or if mango crashes for whatever reason, a deadlock would occurr due to queue.recv() never returning