### PR TITLE
fix(Wayland): increase event timeout to 3s from 100ms

### DIFF
--- a/src/gamescope/wayland/manager.rs
+++ b/src/gamescope/wayland/manager.rs
@@ -456,7 +456,7 @@ impl WaylandManager {
 
         // Wait for readable signal or until a timeout
         let timeout_result = tokio::time::timeout(
-            Duration::from_millis(100),
+            Duration::from_millis(3000),
             Self::wait_for_events(event_queue),
         )
         .await;


### PR DESCRIPTION
This should fix screenshots, which may take longer than 100ms to respond.