### PR TITLE
fix: Register the systemd service as dbus type

### DIFF
--- a/rootfs/usr/lib/systemd/user/gamescope-dbus.service
+++ b/rootfs/usr/lib/systemd/user/gamescope-dbus.service
@@ -2,6 +2,8 @@
 Description=Gamescope DBus Service
 
 [Service]
+Type=dbus
+BusName=org.shadowblip.Gamescope
 ExecStart=/usr/bin/gamescope-dbus
 Restart=on-failure
 RestartSec=1s


### PR DESCRIPTION
This allows systemd to wait until the bus is ready instead of just starting the process and prevents a race condition with gamescope-session to happen.